### PR TITLE
FEAT - Improvements to desktop environment

### DIFF
--- a/ansible/roles/ddhn.setup/tasks/desktop.yml
+++ b/ansible/roles/ddhn.setup/tasks/desktop.yml
@@ -1,5 +1,8 @@
+---
+# desktop Environment setup for DDHN tools
 
-
-gsettings set org.gnome.desktop.background primary-color "#FFFFFF"
-gsettings set org.gnome.desktop.background secondary-color "#FFFFFF"
-gsettings set org.gnome.desktop.background color-shading-type "solid"
+- name: "Desktop | Enable desktop icons"
+  become: true
+  become_user: "{{ ddhn.setup.limited_account.name }}"
+  shell: |
+    dbus-launch gsettings set org.gnome.desktop.background show-desktop-icons true

--- a/ansible/roles/ddhn.setup/tasks/main.yml
+++ b/ansible/roles/ddhn.setup/tasks/main.yml
@@ -12,3 +12,6 @@
 
 - name: "DDHN SETUP | Secure server."
   import_tasks: security/main.yml
+
+- name: "DDHN SETUP | Setup desktop environment."
+  import_tasks: desktop.yml

--- a/ansible/roles/ddhn.setup/tasks/user.yml
+++ b/ansible/roles/ddhn.setup/tasks/user.yml
@@ -1,7 +1,7 @@
 ---
 # Main task entry point for ddhn.setup
 
-- name: "SYS | Creating user account: {{ ddhn.setup.limited_account.name }}."
+- name: "USER | Creating user account: {{ ddhn.setup.limited_account.name }}."
   user:
     name: "{{ ddhn.setup.limited_account.name }}"
     comment: "Sudo user account for server admin."
@@ -12,8 +12,23 @@
     password: "{{ ddhn.setup.limited_account.password }}"
     update_password: always
 
-- name: "SYS | Set authorized key for user: {{ ddhn.setup.limited_account.name }}, copied from current user"
+- name: "USER | Set authorized key for user: {{ ddhn.setup.limited_account.name }}, copied from current user"
   authorized_key:
     user: "{{ ddhn.setup.limited_account.name }}"
     state: present
     key: "{{ lookup('file', lookup('env','HOME') + '/.ssh/id_rsa.pub') }}"
+
+- name: "USER | Create user desktop dir."
+  file:
+    path: "{{ ddhn.setup.limited_account.home }}/Desktop"
+    state: directory
+    mode: '0775'
+    owner: "{{ ddhn.setup.limited_account.name }}"
+    group: "{{ ddhn.setup.limited_account.name }}"
+    mode: a+x
+
+- name: "USER | Set up auto login via /etc/gdm3/daemon.conf"
+  template:
+    src: "etc/gdm3/daemon.j2"
+    dest: "/etc/gdm3/daemon.conf"
+    owner: "root"

--- a/ansible/roles/ddhn.setup/templates/etc/gdm3/daemon.j2
+++ b/ansible/roles/ddhn.setup/templates/etc/gdm3/daemon.j2
@@ -1,0 +1,29 @@
+# GDM configuration storage
+#
+# See /usr/share/gdm/gdm.schemas for a list of available options.
+
+[daemon]
+# Uncoment the line below to force the login screen to use Xorg
+#WaylandEnable=false
+
+# Enabling automatic login
+AutomaticLoginEnable=True
+AutomaticLogin={{ ddhn.setup.limited_account.name }}
+
+
+# Enabling timed login
+#  TimedLoginEnable = true
+#  TimedLogin = user1
+#  TimedLoginDelay = 10
+
+[security]
+
+[xdmcp]
+
+[chooser]
+
+[debug]
+# Uncomment the line below to turn on debugging
+# More verbose logs
+# Additionally lets the X server dump core if it crashes
+#Enable=true

--- a/ansible/roles/ddhn.tools/defaults/main.yml
+++ b/ansible/roles/ddhn.tools/defaults/main.yml
@@ -10,6 +10,9 @@ ddhn_usr_share: "/usr/share"
 ddhn_apps_share: "{{ ddhn_usr_share }}/applications"
 ddhn_icons_share: "{{ ddhn_usr_share }}/icons"
 
+# Account name
+ddhn_account_name: "{{ ddhn_env_user_name | default('vagrant') }}"
+
 # JHOVE version details, to override set jhove_major_minor and jhove_patch
 jhove_major: "1"
 jhove_minor: "24"

--- a/ansible/roles/ddhn.tools/tasks/tool.yml
+++ b/ansible/roles/ddhn.tools/tasks/tool.yml
@@ -18,7 +18,16 @@
     src: "files{{ ddhn_icons_share }}/{{ item.icon }}"
     dest: "{{ ddhn_icons_share }}/{{ item.icon }}"
 
-- name: "TOOL {{ item.name }} | Create desktop from template"
+- name: "TOOL {{ item.name }} | Create shared desktop file from template"
   template:
     src: "usr/share/applications/template.desktop"
     dest: "{{ ddhn_apps_share }}/{{ item.name }}.desktop"
+    mode: a+x
+
+- name: "TOOL {{ item.name }} | Create user desktop file from template"
+  template:
+    src: "usr/share/applications/template.desktop"
+    dest: "/home/{{ ddhn_account_name }}/Desktop/{{ item.name }}.desktop"
+    owner: "{{ ddhn_account_name }}"
+    group: "{{ ddhn_account_name }}"
+    mode: a+x


### PR DESCRIPTION
- enable GNOME display of desktop icons via `gsettings`;
- create `~/Desktop` dir and add application icons;
- enable autologin of default account via `/etc/gdm3/daemon.conf`;
- create desktop shortcuts for installed tools; and
- ensure setup tools role has access to account name.