### PR TITLE
FEAT: Upgrade OS to Debian 11 (bullseye)

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,50 +12,20 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "debian/contrib-stretch64"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # NOTE: This will enable public access to the opened port
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine and only allow access
-  # via 127.0.0.1 to disable public access
-  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
+  config.vm.box = "debian/bullseye64"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
   # Disable default vagrant share
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  config.vm.network "private_network", ip: "192.168.10.220"
-
+  # Provider-specific configuration so you can fine-tune VirtualBox
+  # provider for Vagrant. These expose provider-specific options.
   config.vm.provider "virtualbox" do |vb|
     # Name the prototype machine
-    vb.name = "DDHN Prototype"
+    vb.name = "DDHN v1.1 RC"
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
     # Customize the CPUs (2x) and memory (4GB) on the VM:
@@ -64,12 +34,13 @@ Vagrant.configure("2") do |config|
     # Now set an execution cap at 50 % if required
     # vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     # We need extra Video RAM for display flexibility
-    vb.customize ["modifyvm", :id, "--vram", "64"]
+    vb.customize ["modifyvm", :id, "--vram", "128"]
     # Set up bi-directional clipboard plus drag and drop
     vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
   end
 
+  # Enable provisioning with local ansible playbook.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/initialise-env.yml"
     ansible.verbose = "vv"
@@ -78,15 +49,4 @@ Vagrant.configure("2") do |config|
     ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
     ansible.inventory_path = "ansible/vagrant.yml"
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
 end

--- a/ansible/host_vars/env.ddhn.test
+++ b/ansible/host_vars/env.ddhn.test
@@ -1,6 +1,7 @@
 ---
 
-ansible_ssh_host: "192.168.10.220"
+ansible_ssh_host: "127.0.0.1"
+ansible_ssh_port: 2222
 opf_server_hostname: "env"
 opf_server_hostdomain: "ddhn.test"
 opf_server_fqdn: "{{ opf_server_hostname }}.{{ opf_server_hostdomain }}"

--- a/ansible/roles/ddhn.setup/defaults/main.yml
+++ b/ansible/roles/ddhn.setup/defaults/main.yml
@@ -12,15 +12,11 @@ ddhn_env_apt_defaults:
   - zip
   - unzip
   # Open JDK 8 for Java
-  - openjdk-8-jre
-  - openjdk-8-doc
-  - openjdk-8-source
+  - openjdk-11-jre
+  - openjdk-11-doc
+  - openjdk-11-source
   # GNOME desktop
   - task-gnome-desktop
-  # Debian package for mediainfo GUI
-  - mediainfo-gui
-  # Debian handbrake installation for now
-  - handbrake
 
 virtualbox_remove_os_packages: true
 virtualbox_x11: true

--- a/ansible/roles/ddhn.tools/tasks/tika.yml
+++ b/ansible/roles/ddhn.tools/tasks/tika.yml
@@ -10,7 +10,6 @@
   get_url:
     url: "{{ ddhn.tools.tika.installer.loc }}"
     dest: "{{ ddhn.tools.tika.dests.lib }}/tika-app-{{ tika_version }}.jar"
-    remote_src: yes
 
 - name: "TIKA | Copy the tika shell file."
   template:


### PR DESCRIPTION
- Changes to `Vagrantfile`:

  + use `debian/bullseye64` as vagrant base box;
  + upped video RAM to 128Kb;
  + removed dedicated static IP address to accomodate vagrant best practise;
  + bumped version to v1.1 RC; and
  + removed cruft from file.

- Now using local host and vagrant default port for ansible SSH;
- Upgraded Open JDK from v8 to v11 for latest Debian version;
- Removed tools from setup package install (MediaInfo and Handbrake); and
- removed defunct `remote_src: yes` parameter from `get_url` ansible call.