### PR TITLE
FEAT: Media Conch installation

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,50 +12,20 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "debian/contrib-stretch64"
-
-  # Disable automatic box update checking. If you disable this, then
-  # boxes will only be checked for updates when the user runs
-  # `vagrant box outdated`. This is not recommended.
-  # config.vm.box_check_update = false
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  # NOTE: This will enable public access to the opened port
-  # config.vm.network "forwarded_port", guest: 80, host: 8080
-
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine and only allow access
-  # via 127.0.0.1 to disable public access
-  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
-
-  # Create a private network, which allows host-only access to the machine
-  # using a specific IP.
-  # config.vm.network "private_network", ip: "192.168.33.10"
-
-  # Create a public network, which generally matched to bridged network.
-  # Bridged networks make the machine appear as another physical device on
-  # your network.
-  # config.vm.network "public_network"
+  config.vm.box = "debian/bullseye64"
 
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
   # Disable default vagrant share
   config.vm.synced_folder '.', '/vagrant', disabled: true
 
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  config.vm.network "private_network", ip: "192.168.10.220"
-
+  # Provider-specific configuration so you can fine-tune VirtualBox
+  # provider for Vagrant. These expose provider-specific options.
   config.vm.provider "virtualbox" do |vb|
     # Name the prototype machine
-    vb.name = "DDHN Prototype"
+    vb.name = "DDHN v1.1 RC"
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
     # Customize the CPUs (2x) and memory (4GB) on the VM:
@@ -64,12 +34,13 @@ Vagrant.configure("2") do |config|
     # Now set an execution cap at 50 % if required
     # vb.customize ["modifyvm", :id, "--cpuexecutioncap", "50"]
     # We need extra Video RAM for display flexibility
-    vb.customize ["modifyvm", :id, "--vram", "64"]
+    vb.customize ["modifyvm", :id, "--vram", "128"]
     # Set up bi-directional clipboard plus drag and drop
     vb.customize ["modifyvm", :id, "--clipboard", "bidirectional"]
     vb.customize ["modifyvm", :id, "--draganddrop", "bidirectional"]
   end
 
+  # Enable provisioning with local ansible playbook.
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "ansible/initialise-env.yml"
     ansible.verbose = "vv"
@@ -78,15 +49,4 @@ Vagrant.configure("2") do |config|
     ansible.galaxy_command = "ansible-galaxy install --role-file=%{role_file}"
     ansible.inventory_path = "ansible/vagrant.yml"
   end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
 end

--- a/ansible/host_vars/env.ddhn.test
+++ b/ansible/host_vars/env.ddhn.test
@@ -1,6 +1,7 @@
 ---
 
-ansible_ssh_host: "192.168.10.220"
+ansible_ssh_host: "127.0.0.1"
+ansible_ssh_port: 2222
 opf_server_hostname: "env"
 opf_server_hostdomain: "ddhn.test"
 opf_server_fqdn: "{{ opf_server_hostname }}.{{ opf_server_hostdomain }}"

--- a/ansible/roles/ddhn.setup/defaults/main.yml
+++ b/ansible/roles/ddhn.setup/defaults/main.yml
@@ -15,8 +15,9 @@ ddhn_env_apt_defaults:
   - openjdk-11-jre
   - openjdk-11-doc
   - openjdk-11-source
-  # GNOME desktop
+  # GNOME desktop and Nemo add on for icon display
   - task-gnome-desktop
+  - nemo
 
 virtualbox_remove_os_packages: true
 virtualbox_x11: true

--- a/ansible/roles/ddhn.setup/defaults/main.yml
+++ b/ansible/roles/ddhn.setup/defaults/main.yml
@@ -12,15 +12,11 @@ ddhn_env_apt_defaults:
   - zip
   - unzip
   # Open JDK 8 for Java
-  - openjdk-8-jre
-  - openjdk-8-doc
-  - openjdk-8-source
+  - openjdk-11-jre
+  - openjdk-11-doc
+  - openjdk-11-source
   # GNOME desktop
   - task-gnome-desktop
-  # Debian package for mediainfo GUI
-  - mediainfo-gui
-  # Debian handbrake installation for now
-  - handbrake
 
 virtualbox_remove_os_packages: true
 virtualbox_x11: true

--- a/ansible/roles/ddhn.setup/files/home/.config/autostart/nemo-autostart-with-gnome.desktop
+++ b/ansible/roles/ddhn.setup/files/home/.config/autostart/nemo-autostart-with-gnome.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Nemo
+Comment=Start Nemo desktop at log in
+Exec=nemo-desktop
+OnlyShowIn=GNOME;
+AutostartCondition=GSettings org.nemo.desktop show-desktop-icons
+X-GNOME-AutoRestart=true
+NoDisplay=true

--- a/ansible/roles/ddhn.setup/tasks/desktop.yml
+++ b/ansible/roles/ddhn.setup/tasks/desktop.yml
@@ -1,8 +1,15 @@
 ---
 # desktop Environment setup for DDHN tools
 
-- name: "Desktop | Enable desktop icons"
-  become: true
-  become_user: "{{ ddhn.setup.limited_account.name }}"
-  shell: |
-    dbus-launch gsettings set org.gnome.desktop.background show-desktop-icons true
+- name: "Desktop | Create Nemo config directory."
+  file:
+    path: "/home/vagrant/.config/autostart"
+    state: directory
+    mode: '0755'
+    owner: "{{ ddhn_account_name }}"
+    group: "{{ ddhn_account_name }}"
+
+- name: "Desktop | Add hidden desktop file for Nemo and icons"
+  copy:
+    src: "files/home/.config/autostart/nemo-autostart-with-gnome.desktop"
+    dest: "/home/vagrant/.config/autostart/nemo-autostart-with-gnome.desktop"

--- a/ansible/roles/ddhn.tools/defaults/main.yml
+++ b/ansible/roles/ddhn.tools/defaults/main.yml
@@ -13,6 +13,24 @@ ddhn_icons_share: "{{ ddhn_usr_share }}/icons"
 # Account name
 ddhn_account_name: "{{ ddhn_env_user_name | default('vagrant') }}"
 
+# Tools installed via Debian package manager
+ddhn_debian_tools:
+  # Debian package for mediainfo GUI
+  - "mediainfo-gui"
+  # Debian handbrake installation
+  - "handbrake"
+  # Debian Inkscape installation
+  - "inkscape"
+  # Debian GIMP installation
+  - "gimp"
+
+# Desktop icon files for the about to be copied to remote desktop
+ddhn_debian_icons:
+  - "org.gnome.Evince"
+  - "gimp"
+  - "org.inkscape.Inkscape"
+  - "mediainfo-gui"
+
 # JHOVE version details, to override set jhove_major_minor and jhove_patch
 jhove_major: "1"
 jhove_minor: "24"
@@ -21,18 +39,19 @@ jhove_version: "{{ jhove_major }}.{{ jhove_minor }}.{{ jhove_patch }}"
 
 # veraPDF version details, to override set verapdf_major }}.{{ verapdf_minor and vera_patch
 verapdf_major: "1"
-verapdf_minor: "16"
+verapdf_minor: "20"
 verapdf_patch: "1"
 verapdf_version: "{{ verapdf_major }}.{{ verapdf_minor }}.{{ verapdf_patch }}"
 
 droid_major: "6"
 droid_minor: "5"
-droid_version: "{{ droid_major }}.{{ droid_minor }}"
+droid_patch: "2"
+droid_version: "{{ droid_major }}.{{ droid_minor }}.{{ droid_patch }}"
 
 # Apache Tika version details
 tika_major: "1"
-tika_minor: "24"
-tika_patch: "1"
+tika_minor: "28"
+tika_patch: "2"
 tika_version: "{{ tika_major }}.{{ tika_minor }}.{{ tika_patch }}"
 
 ddhn:
@@ -66,7 +85,7 @@ ddhn:
         git: "https://github.com/digital-preservation/droid.git"
         tag: "droid-{{ droid_version }}"
       installer:
-        loc: "https://github.com/digital-preservation/droid/releases/download/droid-{{ droid_version }}/droid-binary-{{ droid_version }}-bin.zip"
+        loc: "https://repo1.maven.org/maven2/uk/gov/nationalarchives/droid-binary/{{ droid_version }}/droid-binary-{{ droid_version }}-bin.zip"
       dests:
         bin: "{{ ddhn_bin }}"
         lib: "{{ ddhn_lib }}/droid/{{ droid_version }}"
@@ -83,7 +102,7 @@ ddhn:
         git: "https://github.com/apache/tika.git"
         tag: "{{ tika_version }}"
       installer:
-        loc: "http://apache.mirror.anlx.net/tika/tika-app-{{ tika_version }}.jar"
+        loc: "https://archive.apache.org/dist/tika/{{ tika_version }}/tika-app-{{ tika_version }}.jar"
       dests:
         bin: "{{ ddhn_bin }}"
         lib: "{{ ddhn_lib }}/tika/{{ tika_version }}"

--- a/ansible/roles/ddhn.tools/defaults/main.yml
+++ b/ansible/roles/ddhn.tools/defaults/main.yml
@@ -15,8 +15,6 @@ ddhn_account_name: "{{ ddhn_env_user_name | default('vagrant') }}"
 
 # Tools installed via Debian package manager
 ddhn_debian_tools:
-  # Debian package for mediainfo GUI
-  - "mediainfo-gui"
   # Debian handbrake installation
   - "handbrake"
   # Debian Inkscape installation
@@ -30,6 +28,7 @@ ddhn_debian_icons:
   - "gimp"
   - "org.inkscape.Inkscape"
   - "mediainfo-gui"
+  - "mediaconch-gui"
 
 # JHOVE version details, to override set jhove_major_minor and jhove_patch
 jhove_major: "1"
@@ -126,3 +125,19 @@ ddhn:
         bin: "{{ ddhn_bin }}"
         lib: "{{ ddhn_lib }}/veraPDF/{{ verapdf_version }}"
         src: "{{ ddhn_src }}/veraPDF/{{ verapdf_version }}"
+    mediaarea:
+      - name: "libzen0v5"
+        download_url: "https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.Debian_11.deb"
+        package_name: "libzen0v5_0.4.39-1_amd64.Debian_11.deb"
+      - name: "libmediainfo0v5"
+        download_url: "https://mediaarea.net/download/binary/libmediainfo0/22.03/libmediainfo0v5_22.03-1_amd64.Debian_11.deb"
+        package_name: "libmediainfo0v5_22.03-1_amd64.Debian_11.deb"
+      - name: "libmediaconch0"
+        download_url: "https://mediaarea.net/download/binary/libmediaconch0/22.03/libmediaconch0_22.03-1_amd64.Debian_11.deb"
+        package_name: "libmediaconch0_22.03-1_amd64.Debian_11.deb"
+      - name: "mediainfo-gui"
+        download_url: "https://mediaarea.net/download/binary/mediainfo-gui/22.03/mediainfo-gui_22.03-1_amd64.Debian_11.deb"
+        package_name: "mediainfo-gui_22.03-1_amd64.Debian_11.deb"
+      - name: "mediaconch-gui"
+        download_url: "https://mediaarea.net/download/binary/mediaconch-gui/22.03/mediaconch-gui_22.03-1_amd64.Debian_11.deb"
+        package_name: "mediaconch-gui_22.03-1_amd64.Debian_11.deb"

--- a/ansible/roles/ddhn.tools/tasks/debTools.yml
+++ b/ansible/roles/ddhn.tools/tasks/debTools.yml
@@ -1,0 +1,26 @@
+---
+###
+# Installation of Debian packaged tools.
+###
+
+- name: "Debian Tools | Install apt package pre-requisites."
+  apt:
+    name: "{{ ddhn_debian_tools }}"
+    state: "latest"
+
+- name: "Debian Tools | Add desktop icons for Debian tools."
+  copy:
+    src: "/usr/share/applications/{{ item }}.desktop"
+    dest: "/home/vagrant/Desktop/{{ item }}.desktop"
+    owner: "{{ ddhn_account_name }}"
+    group: "{{ ddhn_account_name }}"
+    mode: preserve
+    remote_src: yes
+  with_items: "{{ ddhn_debian_icons }}"
+
+- name: "Debian Tools | Set executable permissions for Desktop icons."
+  ansible.builtin.file:
+    path: "/home/vagrant/Desktop/{{ item }}.desktop"
+    state: file
+    mode: "u+x,g+x,o+x"
+  with_items: "{{ ddhn_debian_icons }}"

--- a/ansible/roles/ddhn.tools/tasks/main.yml
+++ b/ansible/roles/ddhn.tools/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 # Main task entry point for ddhn.tools
+- name: "DDHN TOOLS | Install MediaArea tools."
+  import_tasks: mediaarea/main.yml
 
 - name: "DDHN TOOLS | Install Debian Tools."
   import_tasks: debTools.yml

--- a/ansible/roles/ddhn.tools/tasks/main.yml
+++ b/ansible/roles/ddhn.tools/tasks/main.yml
@@ -1,6 +1,9 @@
 ---
 # Main task entry point for ddhn.tools
 
+- name: "DDHN TOOLS | Install Debian Tools."
+  import_tasks: debTools.yml
+
 - name: "DDHN TOOLS | Install JHOVE."
   import_tasks: jhove.yml
 

--- a/ansible/roles/ddhn.tools/tasks/mediaarea/main.yml
+++ b/ansible/roles/ddhn.tools/tasks/mediaarea/main.yml
@@ -1,0 +1,5 @@
+---
+# Install Media Area Tools and dependencies
+- name: "MediaArea Tools | Install Media Area Tools."
+  include_tasks: toolInstall.yml
+  with_items: "{{ ddhn.tools.mediaarea }}"

--- a/ansible/roles/ddhn.tools/tasks/mediaarea/toolInstall.yml
+++ b/ansible/roles/ddhn.tools/tasks/mediaarea/toolInstall.yml
@@ -1,0 +1,17 @@
+---
+# Install Media Area Tools and dependencies
+- name: "MediaArea Tools | Check for existing {{ item.name }} package."
+  command: dpkg-query -W {{ item.name }}
+  register: mediaarea_check_deb
+  failed_when: mediaarea_check_deb.rc > 1
+  changed_when: mediaarea_check_deb.rc == 1
+
+- name: "MediaArea Tools | Download Debian package for {{ item.name }}."
+  get_url: 
+    url="{{ item.download_url }}"
+    dest="/tmp/{{ item.package_name }}"
+  when: mediaarea_check_deb.rc == 1
+
+- name: "MediaArea Tools | Install Debian package for {{ item.name }}."
+  apt: deb="/tmp/{{ item.package_name }}"
+  when: mediaarea_check_deb.rc == 1

--- a/ansible/roles/ddhn.tools/tasks/tika.yml
+++ b/ansible/roles/ddhn.tools/tasks/tika.yml
@@ -10,7 +10,6 @@
   get_url:
     url: "{{ ddhn.tools.tika.installer.loc }}"
     dest: "{{ ddhn.tools.tika.dests.lib }}/tika-app-{{ tika_version }}.jar"
-    remote_src: yes
 
 - name: "TIKA | Copy the tika shell file."
   template:


### PR DESCRIPTION
- new `mediaarea` task called from `ddhn.tools`;
  - checks if debian package is installed; and
  - downloads and installs missing packages from MediaArea site;
- added mediainfo package details to `ansible/roles/ddhn.tools/defaults/main.yml`;
- added copy for MediaConch icon; and
- removed old mediainfo-gui Debian package.