### PR TITLE
REL: VRE v1.1 RC2

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure("2") do |config|
   # provider for Vagrant. These expose provider-specific options.
   config.vm.provider "virtualbox" do |vb|
     # Name the prototype machine
-    vb.name = "DDHN v1.1 RC"
+    vb.name = "DDHN v1.1 RC2"
     # Display the VirtualBox GUI when booting the machine
     vb.gui = true
     # Customize the CPUs (2x) and memory (4GB) on the VM:

--- a/ansible/initialise-env.yml
+++ b/ansible/initialise-env.yml
@@ -29,6 +29,6 @@
 - hosts: all
   become: true
   roles:
-    - { role: PeterMosmans.virtualbox-guest }
     - { role: ddhn.setup }
+    - { role: PeterMosmans.virtualbox-guest }
     - { role: ddhn.tools }

--- a/ansible/roles/ddhn.setup/defaults/main.yml
+++ b/ansible/roles/ddhn.setup/defaults/main.yml
@@ -11,6 +11,9 @@ ddhn_env_apt_defaults:
   # Zip and unzip are always handy
   - zip
   - unzip
+  # Tools for keyboard and console setup
+  - keyboard-configuration
+  - console-setup
   # Open JDK 8 for Java
   - openjdk-11-jre
   - openjdk-11-doc
@@ -41,36 +44,15 @@ ddhn:
       https: "{{ ddhn_env_port_https | default('') }}"
     open_ports: "{{ ddhn_env_open_ports | default([]) }}"
     limited_account:
-      name: "{{ ddhn_env_user_name | default('vagrant') }}"
-      password: "{{ ddhn_env_user_password | default('$6$D.o3KgyK$3k1LYzMBfQBTXfp0GMzAuKpLp1TwKGb/Q0eVc5sP7sdlb.0TIeBOMISmIidT8CFqdOwU240Bnfp8On7484UCk1') }}"
-      home: "{{ ddhn_env_user_home | default('/home/vagrant') }}"
+      name: "{{ ddhn_env_user_name | default('vre') }}"
+      password: ""
+      home: "{{ ddhn_env_user_home | default('/home/vre') }}"
     default_locale: en_GB.UTF-8
     locales:
       - da_DK.UTF-8
-      - de_AT.UTF-8
-      - de_BE.UTF-8
-      - de_CH.UTF-8
       - de_DE.UTF-8
-      - en_CA.UTF-8
       - en_GB.UTF-8
       - en_US.UTF-8
-      - es_ES.UTF-8
-      - et_EE.UTF-8
-      - fi_FI.UTF-8
-      - fr_BE.UTF-8
       - fr_FR.UTF-8
-      - hr_HR.UTF-8
-      - hu_HU.UTF-8
-      - is_IS.UTF-8
-      - it_IT.UTF-8
-      - lt_LT.UTF-8
-      - lv_LV.UTF-8
-      - nl_BE.UTF-8
       - nl_NL.UTF-8
-      - nn_NO.UTF-8
-      - pt_PT.UTF-8
-      - ro_RO.UTF-8
-      - sv_SE.UTF-8
-      - tr_TR.UTF-8
-      - uk_UA.UTF-8
 

--- a/ansible/roles/ddhn.setup/defaults/main.yml
+++ b/ansible/roles/ddhn.setup/defaults/main.yml
@@ -44,3 +44,33 @@ ddhn:
       name: "{{ ddhn_env_user_name | default('vagrant') }}"
       password: "{{ ddhn_env_user_password | default('$6$D.o3KgyK$3k1LYzMBfQBTXfp0GMzAuKpLp1TwKGb/Q0eVc5sP7sdlb.0TIeBOMISmIidT8CFqdOwU240Bnfp8On7484UCk1') }}"
       home: "{{ ddhn_env_user_home | default('/home/vagrant') }}"
+    default_locale: en_GB.UTF-8
+    locales:
+      - da_DK.UTF-8
+      - de_AT.UTF-8
+      - de_BE.UTF-8
+      - de_CH.UTF-8
+      - de_DE.UTF-8
+      - en_CA.UTF-8
+      - en_GB.UTF-8
+      - en_US.UTF-8
+      - es_ES.UTF-8
+      - et_EE.UTF-8
+      - fi_FI.UTF-8
+      - fr_BE.UTF-8
+      - fr_FR.UTF-8
+      - hr_HR.UTF-8
+      - hu_HU.UTF-8
+      - is_IS.UTF-8
+      - it_IT.UTF-8
+      - lt_LT.UTF-8
+      - lv_LV.UTF-8
+      - nl_BE.UTF-8
+      - nl_NL.UTF-8
+      - nn_NO.UTF-8
+      - pt_PT.UTF-8
+      - ro_RO.UTF-8
+      - sv_SE.UTF-8
+      - tr_TR.UTF-8
+      - uk_UA.UTF-8
+

--- a/ansible/roles/ddhn.setup/files/etc/default/keyboard
+++ b/ansible/roles/ddhn.setup/files/etc/default/keyboard
@@ -1,0 +1,8 @@
+# KEYBOARD CONFIGURATION FILE
+# Consult the keyboard(5) and xkeyboard-config(7) manual page.
+
+KBMODEL="pc105"
+XKBLAYOUT="gb,fr,de,nl"
+XKBVARIANT=""
+XKBOPTIONS="grp:alt_shift_toggle"
+BACKSPACE="guess"

--- a/ansible/roles/ddhn.setup/handlers/main.yml
+++ b/ansible/roles/ddhn.setup/handlers/main.yml
@@ -10,3 +10,9 @@
   service:
     name: iptables-persistent
     state: restarted
+
+- name: rebuild locales database
+  command: "{{ item }}"
+  with_items:
+    - dpkg-reconfigure locales -f noninteractive
+    - /usr/sbin/locale-gen

--- a/ansible/roles/ddhn.setup/tasks/desktop.yml
+++ b/ansible/roles/ddhn.setup/tasks/desktop.yml
@@ -3,7 +3,7 @@
 
 - name: "Desktop | Create Nemo config directory."
   file:
-    path: "/home/vagrant/.config/autostart"
+    path: "/home/{{ ddhn_account_name }}/.config/autostart"
     state: directory
     mode: '0755'
     owner: "{{ ddhn_account_name }}"
@@ -12,4 +12,4 @@
 - name: "Desktop | Add hidden desktop file for Nemo and icons"
   copy:
     src: "files/home/.config/autostart/nemo-autostart-with-gnome.desktop"
-    dest: "/home/vagrant/.config/autostart/nemo-autostart-with-gnome.desktop"
+    dest: "/home/{{ ddhn_account_name }}/.config/autostart/nemo-autostart-with-gnome.desktop"

--- a/ansible/roles/ddhn.setup/tasks/prerequisites.yml
+++ b/ansible/roles/ddhn.setup/tasks/prerequisites.yml
@@ -5,3 +5,20 @@
   apt:
     name: "{{ ddhn.setup.prereqs.apt }}"
     state: "latest"
+
+- name: "LOCALE | Set up common locale packages."
+  community.general.locale_gen:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ ddhn.setup.locales }}"
+  notify:
+    - rebuild locales database
+
+- name: "LOCALE | Set default locale."
+  debconf:
+    name: locales
+    question: locales/default_environment_locale
+    value: "{{ ddhn.setup.default_locale }}"
+    vtype: select
+  notify:
+    - rebuild locales database

--- a/ansible/roles/ddhn.setup/tasks/prerequisites.yml
+++ b/ansible/roles/ddhn.setup/tasks/prerequisites.yml
@@ -22,3 +22,8 @@
     vtype: select
   notify:
     - rebuild locales database
+
+- name: "LOCALE | Setup keyboard defaults."
+  copy:
+    src: "files/etc/default/keyboard"
+    dest: "/etc/default/keyboard"

--- a/ansible/roles/ddhn.setup/tasks/user.yml
+++ b/ansible/roles/ddhn.setup/tasks/user.yml
@@ -1,6 +1,11 @@
 ---
 # Main task entry point for ddhn.setup
 
+- name: "USER | Ensure group vboxsf exists"
+  ansible.builtin.group:
+    name: "vboxsf"
+    state: present
+
 - name: "USER | Creating user account: {{ ddhn.setup.limited_account.name }}."
   user:
     name: "{{ ddhn.setup.limited_account.name }}"
@@ -8,11 +13,12 @@
     createhome: yes
     home: "{{ ddhn.setup.limited_account.home }}"
     shell: "/bin/bash"
-    groups: "sudo"
+    groups: "vboxsf"
     password: "{{ ddhn.setup.limited_account.password }}"
     update_password: always
+    append: yes
 
-- name: "USER | Set authorized key for user: {{ ddhn.setup.limited_account.name }}, copied from current user"
+- name: "USER | Set authorized key for user: {{ ddhn.setup.limited_account.name }}, copied from current user."
   authorized_key:
     user: "{{ ddhn.setup.limited_account.name }}"
     state: present
@@ -25,9 +31,14 @@
     mode: '0775'
     owner: "{{ ddhn.setup.limited_account.name }}"
     group: "{{ ddhn.setup.limited_account.name }}"
+
+- name: "USER | Add execute privileges to the desktop dir."
+  file:
+    path: "{{ ddhn.setup.limited_account.home }}/Desktop"
+    state: directory
     mode: a+x
 
-- name: "USER | Set up auto login via /etc/gdm3/daemon.conf"
+- name: "USER | Set up auto login via /etc/gdm3/daemon.conf."
   template:
     src: "etc/gdm3/daemon.j2"
     dest: "/etc/gdm3/daemon.conf"

--- a/ansible/roles/ddhn.tools/defaults/main.yml
+++ b/ansible/roles/ddhn.tools/defaults/main.yml
@@ -11,7 +11,7 @@ ddhn_apps_share: "{{ ddhn_usr_share }}/applications"
 ddhn_icons_share: "{{ ddhn_usr_share }}/icons"
 
 # Account name
-ddhn_account_name: "{{ ddhn_env_user_name | default('vagrant') }}"
+ddhn_account_name: "{{ ddhn_env_user_name | default('vre') }}"
 
 # Tools installed via Debian package manager
 ddhn_debian_tools:
@@ -32,14 +32,14 @@ ddhn_debian_icons:
 
 # JHOVE version details, to override set jhove_major_minor and jhove_patch
 jhove_major: "1"
-jhove_minor: "24"
+jhove_minor: "26"
 jhove_patch: "1"
 jhove_version: "{{ jhove_major }}.{{ jhove_minor }}.{{ jhove_patch }}"
 
 # veraPDF version details, to override set verapdf_major }}.{{ verapdf_minor and vera_patch
 verapdf_major: "1"
 verapdf_minor: "20"
-verapdf_patch: "1"
+verapdf_patch: "3"
 verapdf_version: "{{ verapdf_major }}.{{ verapdf_minor }}.{{ verapdf_patch }}"
 
 droid_major: "6"
@@ -50,7 +50,7 @@ droid_version: "{{ droid_major }}.{{ droid_minor }}.{{ droid_patch }}"
 # Apache Tika version details
 tika_major: "1"
 tika_minor: "28"
-tika_patch: "2"
+tika_patch: "4"
 tika_version: "{{ tika_major }}.{{ tika_minor }}.{{ tika_patch }}"
 
 ddhn:
@@ -130,14 +130,14 @@ ddhn:
         download_url: "https://mediaarea.net/download/binary/libzen0/0.4.39/libzen0v5_0.4.39-1_amd64.Debian_11.deb"
         package_name: "libzen0v5_0.4.39-1_amd64.Debian_11.deb"
       - name: "libmediainfo0v5"
-        download_url: "https://mediaarea.net/download/binary/libmediainfo0/22.03/libmediainfo0v5_22.03-1_amd64.Debian_11.deb"
-        package_name: "libmediainfo0v5_22.03-1_amd64.Debian_11.deb"
+        download_url: "https://mediaarea.net/download/binary/libmediainfo0/22.06/libmediainfo0v5_22.06-1_amd64.Debian_11.deb"
+        package_name: "libmediainfo0v5_22.06-1_amd64.Debian_11.deb"
       - name: "libmediaconch0"
         download_url: "https://mediaarea.net/download/binary/libmediaconch0/22.03/libmediaconch0_22.03-1_amd64.Debian_11.deb"
         package_name: "libmediaconch0_22.03-1_amd64.Debian_11.deb"
       - name: "mediainfo-gui"
-        download_url: "https://mediaarea.net/download/binary/mediainfo-gui/22.03/mediainfo-gui_22.03-1_amd64.Debian_11.deb"
-        package_name: "mediainfo-gui_22.03-1_amd64.Debian_11.deb"
+        download_url: "https://mediaarea.net/download/binary/mediainfo-gui/22.06/mediainfo-gui_22.06-1_amd64.Debian_11.deb"
+        package_name: "mediainfo-gui_22.06-1_amd64.Debian_11.deb"
       - name: "mediaconch-gui"
         download_url: "https://mediaarea.net/download/binary/mediaconch-gui/22.03/mediaconch-gui_22.03-1_amd64.Debian_11.deb"
         package_name: "mediaconch-gui_22.03-1_amd64.Debian_11.deb"

--- a/ansible/roles/ddhn.tools/tasks/debTools.yml
+++ b/ansible/roles/ddhn.tools/tasks/debTools.yml
@@ -11,7 +11,7 @@
 - name: "Debian Tools | Add desktop icons for Debian tools."
   copy:
     src: "/usr/share/applications/{{ item }}.desktop"
-    dest: "/home/vagrant/Desktop/{{ item }}.desktop"
+    dest: "/home/{{ ddhn_account_name }}/Desktop/{{ item }}.desktop"
     owner: "{{ ddhn_account_name }}"
     group: "{{ ddhn_account_name }}"
     mode: preserve
@@ -20,7 +20,7 @@
 
 - name: "Debian Tools | Set executable permissions for Desktop icons."
   ansible.builtin.file:
-    path: "/home/vagrant/Desktop/{{ item }}.desktop"
+    path: "/home/{{ ddhn_account_name }}/Desktop/{{ item }}.desktop"
     state: file
     mode: "u+x,g+x,o+x"
   with_items: "{{ ddhn_debian_icons }}"


### PR DESCRIPTION
- bumped version number -> `v1.1 RC2`;
- minor tool updates:
  - JHOVE `v1.24.1 -> v1.26.1`;
  - veraPDF `v1.20.3 -> v1.20.3`;
  - Tika `v1.28,2 -> 1.28.4`;
  - MediaInfo `v22.03 -> v22.06`;
- minor fixes to locale setup to make keyboards switchable;
- various fixes to ansible roles to make user details truly configurable;
- new `vre` default user in `vboxsf` group and passwordless access;
- removed excessive locales causing image bloat; and
- VirtualBox Guest Additions installation now last step in server setup process.
