### PR TITLE
Update install-guest-additions.sh

### DIFF
--- a/scripts/install-guest-additions.sh
+++ b/scripts/install-guest-additions.sh
@@ -6,6 +6,9 @@ set -e
 
 echo "Installing VirtualBox Guest Additions..."
 
+# Enable contrib repository for VirtualBox packages
+sudo sed -i 's/main$/main contrib/' /etc/apt/sources.list
+
 # Update package lists
 sudo apt-get update
 


### PR DESCRIPTION
Enable contrib repo for VirtualBox guest additions packages

VirtualBox packages are in Debian's contrib repository which is not enabled by default. Add repository configuration before attempting to install the packages.